### PR TITLE
Modify Regex for Sets

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -50,7 +50,7 @@ Format: `:help`
 
 Adds an exercise that we have done for the day.
 
-Format: `:a <exercise name> <weight(kg)> <sets> <reps>`
+Format: `:a n/<exercise name> w/<weight(kg)> s/<sets> r/<reps>`
 
 ##### Parameter constraints:
 * The weight **must be a positive decimal number**
@@ -103,17 +103,18 @@ Format: `:wq`
 
 ## Command Summary
 
-| Action              | Format                                   | Examples        |
-|---------------------|------------------------------------------|-----------------|
-| **Add exercise**    | :a <exercise> <weight(kg)> <sets> <reps> | :a squat 60 5 5 |
-| **Delete exercise** | :d <index>                               | :d 3            |
-| **List exercises**  | :ls                                      | :ls             |
-| **Help menu**       | :help                                    | :help           |
-| **Exit program**    | :wq                                      | :wq             |
+| Action              | Format                                           | Examples                |
+|---------------------|--------------------------------------------------|-------------------------|
+| **Add exercise**    | :a n/<exercise> w/<weight(kg)> s/<sets> r/<reps> | :a n/Squat w/60 s/5 r/5 |
+| **Delete exercise** | :d <index>                                       | :d 3                    |
+| **List exercises**  | :ls                                              | :ls                     |
+| **Help menu**       | :help                                            | :help                   |
+| **Exit program**    | :wq                                              | :wq                     |
 
 --------------------------------------------------------------------------------------------------------------------
 
 ## Glossary of Terminologies 
-* **Exercise** : Activity requiring physical effort, carried out to sustain or improve health and fitness
+* **Exercise** : Physical activity done in a regular gym that is planned, structured, and repetitive and has as a final 
+or an intermediate objective to the improvement or maintenance of physical fitness
 * **Reps** : Number of times you perform a specific exercise 
 * **Sets** : Number of cycles of reps that you complete 

--- a/src/main/java/gim/model/exercise/Sets.java
+++ b/src/main/java/gim/model/exercise/Sets.java
@@ -9,8 +9,9 @@ import static java.util.Objects.requireNonNull;
  */
 public class Sets {
 
-    public static final String MESSAGE_CONSTRAINTS = "Sets can only take non negative integer values";
-    public static final String VALIDATION_REGEX = "^[0-9]\\d*$";
+    public static final String MESSAGE_CONSTRAINTS = "Sets can only take positive integer values, up to 3 digits";
+    public static final String VALIDATION_REGEX = "^(?:([1-9])|([1-9][0-9])|([1-9][0-9][0-9]))$";
+
 
     public final String value;
 

--- a/src/test/java/gim/model/exercise/SetsTest.java
+++ b/src/test/java/gim/model/exercise/SetsTest.java
@@ -29,6 +29,11 @@ public class SetsTest {
         assertFalse(Sets.isValidSets(" ")); // spaces only
         assertFalse(Sets.isValidSets("abc")); // not an integer
         assertFalse(Sets.isValidSets("-1")); // negative integer
+        assertFalse(Sets.isValidSets("0")); // zero
+        assertFalse(Sets.isValidSets("3.5")); // positive decimal
+        assertFalse(Sets.isValidSets("-1.5")); // negative decimal
+        assertFalse(Sets.isValidSets("01")); // leading zeros
+        assertFalse(Sets.isValidSets("10000")); // positive integer above 3 digits
 
         // valid sets
         assertTrue(Sets.isValidSets("3")); // single digit


### PR DESCRIPTION
Modify REGEX for Sets to ensure sets only accept up to 3 digit positive integers with no leading zeroes.
Include more test statements for JUnit test for Sets.
Update command example and exercise definition in UserGuide.